### PR TITLE
upgraded pyqt dependencies because pyqt5-sip==4.19.19 is no longer available for PIP install

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Now your device is flashed, you may now
 
 ### Linux
 
-Currently Linux builds require *Python 3.6* (but 3.7 seems to work fine as
+Currently Linux builds require *Python 3.6* (but 3.7 and 3.9 seems to work fine as
 well), GNU make and Qt Linguist tools. Following packages should suffice on
-Ubuntu (tested on Ubuntu 18.04):
+Ubuntu (tested on Ubuntu 18.04 and Ubuntu 20.04):
 
     sudo apt install qttools5-dev-tools pyqt5-dev-tools qt5-default python3-pip python3.6 make
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ netifaces==0.10.7
 pefile==2018.8.8
 pyaes==1.6.1
 pyinstaller==3.6
-pyqt5-sip==4.19.19
-pyqt5==5.11.2
+pyqt5-sip==12.12.1
+pyqt5==5.15.9
 pyserial==3.4
 requests==2.20.0
 urllib3==1.24.2


### PR DESCRIPTION
The same fix also works for lower versions of airrohr firmware flasher (tested with 0.3.2)