### PR TITLE
Fixes for the initial wifi/sensor configuration upload

### DIFF
--- a/airrohr-flasher.py
+++ b/airrohr-flasher.py
@@ -427,7 +427,7 @@ class MainWindow(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             args.extend(["spiffsgen.py",
                      "--page-size", "256",
                      "--block-size", "8192",
-                     "--meta-len=0", "0x100000"])
+                     "--meta-len=0", "0x2FA000"])
 
             args.append("--no-magic-len")
             args.append("--aligned-obj-ix-tables")

--- a/airrohr-flasher.py
+++ b/airrohr-flasher.py
@@ -357,6 +357,9 @@ class MainWindow(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.statusbar.clearMessage()
         
         device = self.boardBox.currentData(ROLE_DEVICE)
+        init_baud = ESPLoader.ESP_ROM_BAUD
+        esp = ESPLoader.detect_chip(device, init_baud, 'default_reset', False)
+        self.sensorID = esp.chip_id()
 
         configstring = '{"SOFTWARE_VERSION":"flashingtool","current_lang":"","wlanssid":"","wlanpwd":"","www_username":"admin","www_password":"","fs_ssid":"","fs_pwd":"","www_basicauth_enabled":false,"dht_read":false,"htu21d_read":false,"ppd_read":false,"sds_read":false,"pms_read":false,"hpm_read":false,"npm_read":false,"sps30_read":false,"bmp_read":false,"bmx280_read":false,"sht3x_read":false,"ds18b20_read":false,"dnms_read":false,"dnms_correction":"0.0","temp_correction":"0.0","gps_read":false,"send2dusti":true,"ssl_dusti":false,"send2madavi":true,"ssl_madavi":false,"send2sensemap":false,"send2fsapp":false,"send2aircms":false,"send2csv":false,"auto_update":true,"use_beta":false,"has_display":false,"has_sh1106":false,"has_flipped_display":false,"has_lcd1602":false,"has_lcd1602_27":false,"has_lcd2004":false,"has_lcd2004_27":false,"display_wifi_info":true,"display_device_info":true,"debug":3,"sending_intervall_ms":145000,"time_for_wifi_config":600000,"senseboxid":"","send2custom":false,"host_custom":"192.168.234.1","url_custom":"/data.php","port_custom":80,"user_custom":"","pwd_custom":"","ssl_custom":false,"send2influx":false,"host_influx":"influx.server","url_influx":"/write?db=sensorcommunity","port_influx":8086,"user_influx":"","pwd_influx":"","measurement_name_influx":"feinstaub","ssl_influx":false}'
         self.configjson = json.loads(configstring)

--- a/airrohr-flasher.py
+++ b/airrohr-flasher.py
@@ -388,13 +388,11 @@ class MainWindow(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             return
 
         if not apssid:
-            # self.configjson['fs_ssid'] = "airRohr-" + str(self.sensorID)
-            self.configjson['fs_ssid'] = ""
-            # print(self.configjson['fs_ssid'])
-        else:
-            self.configjson['fs_ssid'] = apssid + "-" + str(self.sensorID)
-            self.customNameSave = apssid
-            print(self.configjson['fs_ssid'])        
+            apssid = "airRohr"
+
+        self.configjson['fs_ssid'] = apssid + "-" + str(self.sensorID)
+        self.customNameSave = apssid
+        print(self.configjson['fs_ssid'])
 
         self.switcher(sensor1)
         self.switcher(sensor2)


### PR DESCRIPTION
This PR has some small fixes to make the Configuration part of the airrohr-flasher work as advertised.

- Create a 3M spiffs partition instead of 1M. The firmware expects a 3M partition and will not recognize a 1M partition created after a full erase. Also OTA updates require 1.5M free space.

- Actually generate a default fs_ssid as airRohr-\<chipid\>. An empty fs_ssid in config.json results in firmware Exceptions because the fs_ssid config setting is also used for the hostname/MDNS-name and can't be empty. This fixes https://github.com/opendata-stuttgart/sensors-software/issues/983